### PR TITLE
terrain material fix: restore use of 4 weight painted textures. was this...

### DIFF
--- a/bin/media/materials/programs/RexTerrainPCF_weighted.cg
+++ b/bin/media/materials/programs/RexTerrainPCF_weighted.cg
@@ -118,12 +118,12 @@ void mainPS(float4 pos    : POSITION,
 {
     //Get texture and their weights
 	float4 weights = tex2D(map0, tex1);
-//	weights /= (weights.x + weights.y + weights.z + weights.w);
-	weights /= (weights.x + weights.y + weights.z);
+	weights /= (weights.x + weights.y + weights.z + weights.w);
+	//weights /= (weights.x + weights.y + weights.z);
     float4 c1 = tex2D(map1, tex0) * weights.x;
     float4 c2 = tex2D(map2, tex0) * weights.y;
     float4 c3 = tex2D(map3, tex0) * weights.z;
-    float4 c4 = float4(0,0,0,0);//tex2D(map4, tex0) * weights.w;
+    float4 c4 = tex2D(map4, tex0) * weights.w; //float4(0,0,0,0);
 
     float lightness = 1.f;
 #ifdef SHADOW_MAPPING


### PR DESCRIPTION
... committed by accident originally? lvm / chesapeake bay uses 4 textures, works correctly in tundra2 with this fix. is there something out there using 3, was the disabling necessary for that, or here just by accident?
