### PR TITLE
BillboardSet.setMaterial -> setMaterialName ogre 1.7.2 build fix for ubuntu 11.04

### DIFF
--- a/src/EntityComponents/EC_HoveringText/EC_HoveringText.cpp
+++ b/src/EntityComponents/EC_HoveringText/EC_HoveringText.cpp
@@ -347,7 +347,7 @@ void EC_HoveringText::AttributesChanged()
     {
         // If the material was cleared, erase the material from Ogre billboard as well.
         if (material.Get().ref.isEmpty() && billboardSet_)
-            billboardSet_->setMaterial(Ogre::MaterialPtr());
+            billboardSet_->setMaterialName(""); //1.7.2 compatibility, up from 1.7.3 can do: Ogre::MaterialPtr());
         else
             materialAsset.HandleAssetRefChange(&material);
     }


### PR DESCRIPTION
this is what i changed to build on 1.7.2 which still have in a ubuntu 11.04 machine.

am not sure if that works actually, docs don't tell really, http://www.ogre3d.org/docs/api/html/classOgre_1_1BillboardSet.html#a7a75cccf0a232780b44e9e11c61e96f7 - now just needed to be able to build first

might be ok to just start requiring 1.7.3 to get rid off this annoyance, but now practical at least for me to have this fix instead.
