### PR TITLE
AvatarDescAsset::AddAttachment: Fix emitting AppearanceChanged() before ...

### DIFF
--- a/src/Application/AvatarModule/AvatarDescAsset.cpp
+++ b/src/Application/AvatarModule/AvatarDescAsset.cpp
@@ -588,7 +588,10 @@ void AvatarDescAsset::AddAttachment(AssetPtr assetPtr)
     {
         ReadAttachment(elem);
         AssetReferencesChanged();
-        emit AppearanceChanged();
+        // If an attachment is added, removed, and added again,
+        // AssetReferencesChanged() doesn't seem to emit AppearanceChanged().
+        if (!assetAPI->HasPendingDependencies(this->shared_from_this()))
+            emit AppearanceChanged();
     }
     else
     {


### PR DESCRIPTION
...dependencies have been loaded.

Trusts that AppearanceRefsChanged() calls it if there are (new) dependencies to be loaded.
