### PR TITLE
EC_Hydrax: Don't update hydrax if a camera is activated which is in another scene that this component is not a part of

### DIFF
--- a/src/Application/SkyXHydrax/EC_Hydrax.cpp
+++ b/src/Application/SkyXHydrax/EC_Hydrax.cpp
@@ -174,6 +174,13 @@ void EC_Hydrax::OnActiveCameraChanged(Entity *newActiveCamera)
         SAFE_DELETE(impl);
         return;
     }
+
+    if (newActiveCamera)
+    {
+        if (newActiveCamera->ParentScene() != ParentScene())
+            return;
+    }
+
     // If we haven't yet initialized, do a full init.
     if (!impl)
         Create();


### PR DESCRIPTION
This is about an issue I have, where EC_Hydrax from one scene renders in another scene without the component being present there. It only renders the underwater part though, meaning the water surface is not rendered.

@Stinkfist0 mentioned if this should be made for EC_SkyX as well.
