### PR TITLE
Linux Mint build, updated extdeps, and Ubuntu fixes

### DIFF
--- a/cmake/ConfigurePackages.cmake
+++ b/cmake/ConfigurePackages.cmake
@@ -433,3 +433,41 @@ macro(link_package_assimp)
         target_link_libraries(${TARGET_NAME} debug assimpd)
     endif()
 endmacro()
+
+macro(use_package_skyx)
+    # SkyX look up rules:
+    # 1. Use cmake cached SKYX_DIR.
+    # 2. Use env variable SKYX_DIR and cache it.
+    # 3. Assume SkyX from deps path.
+
+    message("** Configuring SkyX")
+    if ("${SKYX_DIR}" STREQUAL "")
+        file (TO_CMAKE_PATH "$ENV{SKYX_DIR}" SKYX_DIR)
+        # Cache SKYX_DIR for runs that dont define $ENV{SKYX_DIR}.
+        set (SKYX_DIR ${SKYX_DIR} CACHE PATH "SKYX_DIR dependency path" FORCE)
+    endif ()
+    if ("${SKYX_DIR}" STREQUAL "")
+        if (MSVC)
+            set(SKYX_DIR ${ENV_TUNDRA_DEP_PATH}/SkyX)
+        else()
+            set(SKYX_DIR ${ENV_TUNDRA_DEP_PATH})
+        endif()
+    endif()
+    message (STATUS "Using SKYX_DIR = ${SKYX_DIR}")
+
+    if (WIN32)
+        include_directories(${SKYX_DIR}/include) # For prebuilt VS2008/VS2010 deps.
+        include_directories(${SKYX_DIR}/Include) # For full-built source deps.
+        link_directories(${SKYX_DIR}/lib)
+    else() # Linux and mac
+        include_directories(${SKYX_DIR}/include/SkyX)
+        link_directories(${SKYX_DIR}/lib)
+    endif()
+endmacro()
+
+macro(link_package_skyx)
+    target_link_libraries(${TARGET_NAME} optimized SkyX)
+    if (WIN32)
+        target_link_libraries(${TARGET_NAME} debug SkyX_d)
+    endif()
+endmacro()

--- a/src/Application/SkyXHydrax/CMakeLists.txt
+++ b/src/Application/SkyXHydrax/CMakeLists.txt
@@ -75,6 +75,7 @@ macro(use_package_skyx)
             COMPONENTS SkyX SKYX skyx
             PREFIXES ${ENV_SKYX_HOME} ${ENV_TUNDRA_DEP_PATH})
         set (SKYX_INCLUDE_DIRS ${ENV_TUNDRA_DEP_PATH}/include/SkyX)
+        include_directories(${SKYX_INCLUDE_DIRS})
         sagase_configure_report (SKYX)
     endif()
 endmacro()
@@ -119,7 +120,7 @@ set (FILES_TO_TRANSLATE ${FILES_TO_TRANSLATE} ${H_FILES} ${CPP_FILES} PARENT_SCO
 
 if (ENABLE_SKYX)
     add_definitions(-DSKYX_ENABLED)
-    use_package(SKYX) # Other OSes #TODO:REMOVE THIS!
+#    use_package(SKYX) # Other OSes #TODO:REMOVE THIS!
     use_package_skyx() # Windows 
 endif()
 if (ENABLE_HYDRAX)
@@ -137,7 +138,7 @@ link_modules(Framework Math Scene OgreRenderingModule)
 link_ogre()
 
 if (ENABLE_SKYX)
-    link_package (SKYX)  # Other OSes #TODO:REMOVE THIS!
+#    link_package (SKYX)  # Other OSes #TODO:REMOVE THIS!
     link_package_skyx() # Windows
 endif()
 if (ENABLE_HYDRAX)

--- a/tools/build-ubuntu-deps.bash
+++ b/tools/build-ubuntu-deps.bash
@@ -48,7 +48,10 @@ if lsb_release -c | egrep -q "lucid|maverick|natty|oneiric|precise|maya|lisa|kat
 	 ccache libqt4-dev python-dev freeglut3-dev \
 	 libxml2-dev cmake libalut-dev libtheora-dev ed \
 	 liboil0.3-dev mercurial unzip xsltproc libois-dev libxrandr-dev \
-	 libspeex-dev nvidia-cg-toolkit subversion
+	 libspeex-dev nvidia-cg-toolkit subversion \
+	 libfreetype6-dev libfreeimage-dev libzzip-dev \
+	 libxaw7-dev libgl1-mesa-dev libglu1-mesa-dev
+
 fi
  
 what=bullet-2.80-rev2531
@@ -153,9 +156,9 @@ else
         echo "$what does not exist. Cloning a new copy..."
         hg clone https://bitbucket.org/clb/ogre-safe-nocrashes
     fi
-    if tty > /dev/null; then
-	sudo apt-get build-dep libogre-dev
-    fi
+#    if tty > /dev/null; then
+#	sudo apt-get build-dep libogre-dev
+#    fi
     cd $what
     hg checkout v1-8 # Make sure we are in the right branch
     mkdir -p $what-build
@@ -281,4 +284,7 @@ exec ccache g++ -O -g \$@
 EOF
 chmod +x ccache-g++-wrapper
 TUNDRA_DEP_PATH=$prefix cmake -DCMAKE_CXX_COMPILER="$viewer/ccache-g++-wrapper" . -DCMAKE_MODULE_PATH=$prefix/lib/SKYX/cmake
+
+echo TUNDRA_DEP_PATH > deppath.txt
+echo CMAKE_MODULE_PATH > cmakemodulepath.txt
 make -j $nprocs VERBOSE=1


### PR DESCRIPTION
Fixes SkyX on Ubuntu/Linux Mint, and allows detection of Linux Mint on the Ubuntu script. Also updates some of the extdeps to recent versions, and gets rid of the build breaking removal of the OpenCL directory from CMake in Bullet (which coincidentally improves performance). Note, not tested on Windows.
