### PR TITLE
Fix (Ubuntu) compilation broken for PythonScriptModule.

### DIFF
--- a/src/Application/PythonScriptModule/TundraWrapper.h
+++ b/src/Application/PythonScriptModule/TundraWrapper.h
@@ -48,6 +48,7 @@ namespace PythonScript
         // AssetReference: Construct and destruct
         AssetReference *new_AssetReference();
         AssetReference *new_AssetReference(const QString &reference);
+        AssetReference *new_AssetReference(const QString &assetRef, const QString &assetType);
         void delete_AssetReference(AssetReference *obj);
 
         // AssetReference: Functions


### PR DESCRIPTION
Broken in bf38af7b, a function added to TundraWapper.cpp was missing from the header file.
