### PR TITLE
Revert "Re: #541 - Utilize IComponent::AttributesChanged for EC_ParticleSystem

### DIFF
--- a/src/Core/OgreRenderingModule/EC_Billboard.h
+++ b/src/Core/OgreRenderingModule/EC_Billboard.h
@@ -116,6 +116,9 @@ private slots:
     /// Component removed; check if it was the placeable
     void OnComponentRemoved(IComponent* component, AttributeChange::Type change);
     
+    /// Called when some of the attributes has been changed
+    void OnAttributeUpdated(IAttribute *attribute);
+    
     /// Called when material asset has been downloaded.
     void OnMaterialAssetLoaded(AssetPtr material);
     
@@ -137,8 +140,6 @@ private:
     
     /// Detach billboardset from the placeable's scene node
     void DetachBillboard();
-
-    void AttributesChanged();
 
     /// Ogre world ptr
     OgreWorldWeakPtr world_;

--- a/src/Core/OgreRenderingModule/EC_ParticleSystem.h
+++ b/src/Core/OgreRenderingModule/EC_ParticleSystem.h
@@ -88,13 +88,13 @@ public slots:
     void SoftStopParticleSystem(const QString& systemName = QString());
     
 private slots:
+    void OnAttributeUpdated(IAttribute *attribute);
     void OnParticleAssetLoaded(AssetPtr asset);
     void OnParticleAssetFailed(IAssetTransfer* transfer, QString reason);
     void EntitySet();
     void OnComponentRemoved(IComponent *component, AttributeChange::Type change);
 
 private:
-    void AttibutesChanged();
     ComponentPtr FindPlaceable() const;
 
     std::map<QString, Ogre::ParticleSystem*> particleSystems_;


### PR DESCRIPTION
fixes #607

---rest of the reverted commit message:

...and EC_Billboard components. EC_Fog left untouched intentionally as it wouldn't gain anything from the refactoring (it's not interested in which attributes have been changed, as it does the same update routine always)."

This reverts commit 0fba536ad4316235fc2ae601bf86fab004
