### PR TITLE
proper fix to EC_ParticleSystem refactor: was a typo, changing 'AttibutesChanged' to 'AttributesChanged' fixed it.

### DIFF
--- a/src/Core/OgreRenderingModule/EC_ParticleSystem.cpp
+++ b/src/Core/OgreRenderingModule/EC_ParticleSystem.cpp
@@ -209,7 +209,7 @@ void EC_ParticleSystem::SoftStopParticleSystem(const QString& systemName)
     system->setEmitting(false);
 }
 
-void EC_ParticleSystem::AttibutesChanged()
+void EC_ParticleSystem::AttributesChanged()
 {
     if (!ViewEnabled())
         return;

--- a/src/Core/OgreRenderingModule/EC_ParticleSystem.h
+++ b/src/Core/OgreRenderingModule/EC_ParticleSystem.h
@@ -94,7 +94,7 @@ private slots:
     void OnComponentRemoved(IComponent *component, AttributeChange::Type change);
 
 private:
-    void AttibutesChanged();
+    void AttributesChanged();
     ComponentPtr FindPlaceable() const;
 
     std::map<QString, Ogre::ParticleSystem*> particleSystems_;


### PR DESCRIPTION
is unfortunate that it compiles with such typos. there seems to be discussion how c++ doesn't currently have a crossplat solution to this, http://stackoverflow.com/questions/497630/safely-override-c-virtual-functions

fixes #607
