### PR TITLE
Adminotech windows dependency changes

### DIFF
--- a/cmake/ConfigurePackages.cmake
+++ b/cmake/ConfigurePackages.cmake
@@ -86,7 +86,7 @@ macro (configure_qt4)
     if (NOT ANDROID)
         sagase_configure_package (QT4 
             NAMES Qt4 4.6.1
-            COMPONENTS QtCore QtGui QtWebkit QtScript QtScriptTools QtXml QtNetwork QtUiTools QtDeclarative
+            COMPONENTS QtCore QtGui QtWebkit QtScript QtScriptTools QtXml QtNetwork QtUiTools
 	    PREFIXES ${ENV_QT_DIR} ${ENV_TUNDRA_DEP_PATH})
     else()
         find_package(Qt4 COMPONENTS QtCore QtGui QtXml QtNetwork QtScript QtUiTools)

--- a/tools/windows-build-deps.cmd
+++ b/tools/windows-build-deps.cmd
@@ -257,7 +257,10 @@ IF NOT EXIST "%DEPS%\qt\lib\QtWebKit4.dll". (
 
    IF NOT EXIST "configure.cache". (
       cecho {0D}Configuring Qt build. Please answer 'y'!{# #}{\n}
-      configure -platform %QT_PLATFORM% -debug-and-release -opensource -prefix "%DEPS%\qt" -shared -ltcg -no-qt3support -no-opengl -no-openvg -no-dbus -no-phonon -no-phonon-backend -nomake examples -nomake demos -qt-zlib -qt-libpng -qt-libmng -qt-libjpeg -qt-libtiff %QT_OPENSSL_CONFIGURE%
+      configure -platform %QT_PLATFORM% -debug-and-release -opensource -prefix "%DEPS%\qt" -shared -ltcg ^
+        -no-qt3support -no-opengl -no-openvg -no-dbus -no-phonon -no-phonon-backend -no-multimedia -no-audio-backend ^
+        -no-declarative -no-xmlpatterns -nomake examples -nomake demos ^
+        -qt-zlib -qt-libpng -qt-libmng -qt-libjpeg -qt-libtiff %QT_OPENSSL_CONFIGURE%
 
       IF NOT %ERRORLEVEL%==0 GOTO :ERROR
    ) ELSE (


### PR DESCRIPTION
- Updates windows Qt to 4.8.4. We tried to look for the performance problems that were observer with 4.8.0 but could not reproduce them.
- Removes unwanted projects/options from the Qt build.
- Modifies bullet to be build in both release and relwithdebinfo configurations.

After this code is in you need to remove from `/deps`: qt, QtScriptGenerator, QtPropertyBrowser, QXmpp and bullet.

<b>NOTE:</b> I would recommend merging our bugfix branch before this is pulled in.
