### PR TITLE
Interest management

### DIFF
--- a/src/Core/TundraProtocolModule/EntityPrioritizer.cpp
+++ b/src/Core/TundraProtocolModule/EntityPrioritizer.cpp
@@ -47,7 +47,7 @@ void DefaultEntityPrioritizer::ComputeSyncPriorities(EntitySyncStateMap &entitie
         {
             if (sound->spatial.Get() && placeable)
             {
-                float r = audio->soundOuterRadius.Get();
+                float r = sound->soundOuterRadius.Get();
                 r *= r;
                 entityState.priority = 4.f * pi * r / observerPos.DistanceSq(placeable->WorldPosition());
             }

--- a/src/Core/TundraProtocolModule/EntityPrioritizer.cpp
+++ b/src/Core/TundraProtocolModule/EntityPrioritizer.cpp
@@ -1,0 +1,123 @@
+// For conditions of distribution and use, see copyright notice in LICENSE
+
+#pragma once
+
+#include "StableHeaders.h"
+#define MATH_OGRE_INTEROP
+#include "EntityPrioritizer.h"
+#include "SyncState.h"
+
+#include "Profiler.h"
+#include "Scene.h"
+#include "EC_Placeable.h"
+#include "EC_RigidBody.h"
+#include "EC_Mesh.h"
+#include "OgreMeshAsset.h"
+//#include "EC_Sound.h"
+
+void DefaultEntityPrioritizer::ComputeSyncPriorities(EntitySyncStateMap &entities, const float3 &observerPos,const float3 &observerRot)
+{
+    // IDEA: could cache observerPos and observerRot and recompute priorities only of those are changed.
+    // But of constantly moving objects it's probably good to recompute priorities every once in a while even if 
+    // the observer doesn't move.
+    if (!observerPos.IsFinite() || !observerRot.IsFinite())
+        return; // camera information not received yet.
+    ScenePtr scn = scene.lock();
+    if (!scn)
+        return;
+
+    PROFILE(DefaultEntityPrioritizer_ComputeSyncPriorities);
+    for(EntitySyncStateMap::iterator it = entities.begin(); it != entities.end(); ++it)
+    {
+        EntitySyncState &entityState = it->second;
+        Entity *entity = scn->EntityById(entityState.id).get(); /**< @todo Use EntityWeakPtr in EntitySyncState when available */
+        if (!entity)
+            continue; // we (might) end up here e.g. when entity was just deleted
+
+        /// @todo Check do we end up computing sync prio for local entities
+
+        shared_ptr<EC_Placeable> placeable = entity->Component<EC_Placeable>();
+        shared_ptr<EC_Mesh> mesh = entity->Component<EC_Mesh>();
+        shared_ptr<EC_RigidBody> rigidBody = entity->Component<EC_RigidBody>();
+
+        /// @todo sound sources
+        /*
+        shared_ptr<EC_Sound> sound = entity->Component<EC_Sound>();
+        if (sound)
+        {
+            if (sound->spatial.Get() && placeable)
+            {
+                float r = audio->soundOuterRadius.Get();
+                r *= r;
+                entityState.priority = 4.f * pi * r / observerPos.DistanceSq(placeable->WorldPosition());
+            }
+            else
+                entityState.priority = inf;
+        }
+        */
+        /// @todo Handle terrains
+        //shared_ptr<EC_Terrain> terrain = entity->Component<EC_Terrain>();
+        //if (terrain) { ... }
+
+        if (!placeable)
+        {
+            /// @todo Should handle special case entities with rigid body but no placeable?
+            //if (rigidBody)
+            // Non-spatial (probably), use max priority
+            /// @todo Can have f.ex. Terrain component that has its own transform, but it can use Placeable too.
+            entityState.priority = inf;
+        }
+        else if (placeable && !mesh)
+        {
+            // Spatial, but no mesh, for now use a harcoded priority of 20 (updateInterval = 1 / (priority * relevance),
+            // so will probably yield the default SyncManager's update period 1/20th of a second
+            entityState.priority = 20.f;
+            /// @todo retrieve/calculate bounding volumes of possible billboards, particle systems, lights, etc.
+            /// Not going to be easy with Ogre though, especially when running in headless mode.
+        }
+        else if (placeable && mesh)
+        {
+            OBB worldObb;
+            if (scn->GetFramework()->IsHeadless())
+            {
+                // On headless mode, force mesh asset load in order to be able to inspect its AABB.
+                if (!mesh->MeshAsset() && !mesh->meshRef.Get().ref.trimmed().isEmpty())
+                {
+                    mesh->ForceMeshLoad();
+                    continue; // compute the priority next time when mesh asset is available
+                }
+                // EC_Mesh::WorldOBB not usable in headless mode (no Ogre::Entity available),
+                // so we must dig the bounding volume information from OgreMeshAsset (Ogre::Mesh) instead.
+                /// @todo For some meshes (f.ex. floor of the Avatar scene) there seems to be significant discrepancy
+                // between the OBB values when running as headless or not. Investigate.
+                Ogre::MeshPtr ogreMesh = mesh->MeshAsset() ? mesh->MeshAsset()->ogreMesh : Ogre::MeshPtr();
+                if (ogreMesh.isNull())
+                    LogWarning("SyncManager::ComputeSyncPriorities: " + entity->ToString().toStdString() + " has null Ogre mesh " + mesh->GetMeshName());
+                worldObb = !ogreMesh.isNull() ? AABB(ogreMesh->getBounds()) : OBB();
+                worldObb.Transform(placeable->LocalToWorld());
+            }
+            else
+                worldObb = mesh->WorldOBB();
+            float sizeSq = worldObb.SurfaceArea();
+            sizeSq *= sizeSq;
+            float distanceSq = observerPos.DistanceSq(placeable->WorldPosition());
+            entityState.priority = sizeSq/distanceSq;
+            //LogDebug(QString("%1 sizeSq %2 distanceSq %3").arg(entity->ToString()).arg(sizeSq).arg(distanceSq));
+        }
+
+        /// @todo Take direction and velocity of rigid bodies into account
+            //if (rigibBody)
+        /// @todo Hardcoded relevancy of 10 for entities with RigidBody component and 1 for others for now.
+        /// @todo Movement of non-physical entities is too jerky.
+        entityState.relevancy = rigidBody /*entity->Component("EC_Avatar")*/ ? 10.f : 1.f;
+        //LogDebug(QString("%1 P %2 R %3 P*R %4 syncRate %5").arg(entity->ToString()).arg(
+            //entityState.priority).arg(entityState.relevancy).arg(entityState.FinalPriority()).arg(entityState.ComputePrioritizedUpdateInterval(updatePeriod_)));
+    }
+}
+
+void DefaultEntityPrioritizer::ComputeSyncPriorities(EntitySyncState &entityState, const float3 &observerPos, const float3 &observerRot)
+{
+    EntitySyncStateMap m;
+    m[entityState.id] = entityState;
+    ComputeSyncPriorities(m, observerPos, observerRot);
+}

--- a/src/Core/TundraProtocolModule/EntityPrioritizer.h
+++ b/src/Core/TundraProtocolModule/EntityPrioritizer.h
@@ -13,6 +13,8 @@ class TUNDRAPROTOCOL_MODULE_API EntityPrioritizer
 {
 public:
     /// Computes priorities provided entity sync states.
+    /// @todo In addition, or instead, could provide a function with begin and end iterators as input. This could useful
+    /// when dealing when very large container and only a fixed number of priority calculation would be wanted per frame.
     virtual void ComputeSyncPriorities(EntitySyncStateMap & UNUSED_PARAM(entities), const float3 & UNUSED_PARAM(observerPos),const float3 & UNUSED_PARAM(observerRot))
     {
     }
@@ -21,6 +23,8 @@ public:
     virtual void ComputeSyncPriorities(EntitySyncState & UNUSED_PARAM(entityState), const float3 & UNUSED_PARAM(observerPos), const float3 & UNUSED_PARAM(observerRot))
     {
     }
+
+    /// @todo Provide virtual Sort() function? Prioritizer could sort then dirty queue using custom predicates.
 };
 
 /// Subclass to perform application-specific entity prioritizing.

--- a/src/Core/TundraProtocolModule/EntityPrioritizer.h
+++ b/src/Core/TundraProtocolModule/EntityPrioritizer.h
@@ -1,0 +1,37 @@
+// For conditions of distribution and use, see copyright notice in LICENSE
+
+#pragma once
+
+#include "TundraProtocolModuleFwd.h"
+#include "TundraProtocolModuleApi.h"
+#include "SceneFwd.h"
+
+/// Subclass and provide the implementation to SyncManager to perform application-specific entity prioritizing.
+/** The base class implementations of functions are no-ops.
+    @remark Interest management */
+class TUNDRAPROTOCOL_MODULE_API EntityPrioritizer
+{
+public:
+    /// Computes priorities provided entity sync states.
+    virtual void ComputeSyncPriorities(EntitySyncStateMap & UNUSED_PARAM(entities), const float3 & UNUSED_PARAM(observerPos),const float3 & UNUSED_PARAM(observerRot))
+    {
+    }
+
+     /// @overload
+    virtual void ComputeSyncPriorities(EntitySyncState & UNUSED_PARAM(entityState), const float3 & UNUSED_PARAM(observerPos), const float3 & UNUSED_PARAM(observerRot))
+    {
+    }
+};
+
+/// Subclass to perform application-specific entity prioritizing.
+class TUNDRAPROTOCOL_MODULE_API DefaultEntityPrioritizer : public EntityPrioritizer
+{
+public:
+    explicit DefaultEntityPrioritizer(const SceneWeakPtr &syncedScene) : scene(syncedScene) {}
+    /// EntityPrioritizer override
+    void ComputeSyncPriorities(EntitySyncStateMap &entities, const float3 &observerPos,const float3 &observerRot);
+    /// EntityPrioritizer override
+    void ComputeSyncPriorities(EntitySyncState &entityState, const float3 &observerPos, const float3 &observerRot);
+
+    SceneWeakPtr scene;
+};

--- a/src/Core/TundraProtocolModule/SyncManager.cpp
+++ b/src/Core/TundraProtocolModule/SyncManager.cpp
@@ -1,7 +1,6 @@
 // For conditions of distribution and use, see copyright notice in LICENSE
 
 #include "StableHeaders.h"
-#define MATH_OGRE_INTEROP
 #include "DebugOperatorNew.h"
 
 #include "SyncManager.h"
@@ -10,12 +9,11 @@
 #include "Server.h"
 #include "TundraMessages.h"
 #include "MsgEntityAction.h"
+#include "EntityPrioritizer.h"
+
 #include "Scene/Scene.h"
 #include "Entity.h"
 #include "CoreStringUtils.h"
-#include "EC_DynamicComponent.h"
-#include "AssetAPI.h"
-#include "IAssetStorage.h"
 #include "AttributeMetadata.h"
 #include "LoggingFunctions.h"
 #include "Profiler.h"
@@ -23,9 +21,6 @@
 #include "EC_RigidBody.h"
 #include "SceneAPI.h"
 #include "UserConnection.h"
-#include "EC_Mesh.h"
-#include "OgreMeshAsset.h"
-//#include "EC_Sound.h"
 
 #include <kNet.h>
 
@@ -208,8 +203,8 @@ SyncManager::SyncManager(TundraLogicModule* owner) :
     noClientPhysicsHandoff_(false),
     componentTypeSender_(0),
     prioUpdateAcc_(0.0),
-    interestManagementEnabled_(false),
-    priorityUpdatePeriod_(1.f)
+    priorityUpdatePeriod_(1.f),
+    prioritizer_(0)
 {
     QStringList imArg = framework_->CommandLineParameters("--interestManagement");
     if (!imArg.empty())
@@ -232,6 +227,7 @@ SyncManager::SyncManager(TundraLogicModule* owner) :
 
 SyncManager::~SyncManager()
 {
+    SAFE_DELETE(prioritizer_);
 }
 
 void SyncManager::SetPriorityUpdatePeriod(float period)
@@ -422,12 +418,23 @@ void SyncManager::NewUserConnected(const UserConnectionPtr &user)
         if (entity->IsLocal())
             continue;
         user->syncState->MarkEntityDirty(entity->Id());
-        if (interestManagementEnabled_)
+        if (prioritizer_)
         {
             // MarkEntityDirty() above has created a proper sync state for the entity.
-            ComputeSyncPriorities(user->syncState->entities[entity->Id()], user->syncState->observerPos, user->syncState->observerRot);
+            prioritizer_->ComputeSyncPriorities(user->syncState->entities[entity->Id()], user->syncState->observerPos, user->syncState->observerRot);
         }
     }
+}
+
+void SyncManager::SetInterestManagementEnabled(bool enabled)
+{
+    SetPrioritizer(enabled ? new DefaultEntityPrioritizer(scene_) : 0);
+}
+
+void SyncManager::SetPrioritizer(EntityPrioritizer *prioritizer)
+{
+    SAFE_DELETE(prioritizer_);
+    prioritizer_ =  prioritizer;
 }
 
 void SyncManager::OnAttributeChanged(IComponent* comp, IAttribute* attr, AttributeChange::Type change)
@@ -973,12 +980,14 @@ void SyncManager::Update(f64 frametime)
             if (syncState)
             {
                 // First sort the dirty queue according to priority if IM enabled
-                if (interestManagementEnabled_)
+                if (prioritizer_) /**< @todo Move all code in this block behind EntityPrioritizer? */
                 {
+                    /// @todo Do priority update independently from regular sync update.
                     if (prioUpdateAcc_ >= priorityUpdatePeriod_)
                     {
                         prioUpdateAcc_ = fmod(prioUpdateAcc_, priorityUpdatePeriod_);
-                        ComputeSyncPriorities(syncState->entities, syncState->observerPos, syncState->observerRot);
+                        if (prioritizer_)
+                            prioritizer_->ComputeSyncPriorities(syncState->entities, syncState->observerPos, syncState->observerRot);
                     }
                     PROFILE(SyncManager_Update_SortDirtyQueue);
                     syncState->dirtyQueue.sort();
@@ -1003,11 +1012,10 @@ void SyncManager::Update(f64 frametime)
         if (connection)
         {
             ProcessSyncState(serverConnection_.get());
-            if (interestManagementEnabled_ && prioUpdateAcc_ >= priorityUpdatePeriod_)
+            if (prioritizer_ && prioUpdateAcc_ >= priorityUpdatePeriod_)
             {
                 prioUpdateAcc_ = fmod(prioUpdateAcc_, priorityUpdatePeriod_);
                 SendObserverPosition(serverConnection_.get(), serverConnection_->syncState.get());
-
             }
         }
     }
@@ -1100,7 +1108,7 @@ void SyncManager::ReplicateRigidBodyChanges(UserConnection* user)
 
         float timeSinceLastSend = kNet::Clock::SecondsSinceF(ess.lastNetworkSendTime);
         /// @todo Is this the best place for this check?
-        if (interestManagementEnabled_ && timeSinceLastSend < ess.ComputePrioritizedUpdateInterval(updatePeriod_))
+        if (prioritizer_ && timeSinceLastSend < ess.ComputePrioritizedUpdateInterval(updatePeriod_))
             continue;
 
         const float3 predictedClientSidePosition = ess.transform.pos + timeSinceLastSend * ess.linearVelocity;
@@ -1533,7 +1541,7 @@ void SyncManager::ProcessSyncState(UserConnection* user)
     }
 
     // Interest management sync priorization performed only on the server
-    const bool serverImEnabled = (isServer && interestManagementEnabled_);
+    const bool serverImEnabled = (isServer && prioritizer_);
 
     // Process the state's dirty entity queue.
     std::list<EntitySyncState*>::iterator it = state->dirtyQueue.begin();
@@ -2897,112 +2905,9 @@ void SyncManager::SendObserverPosition(UserConnection *connection, SceneSyncStat
             ds.AddArithmeticEncoded(8, posSendType, 3, rotSendType, 4);
 
             WriteOptimizedPosAndRot(ds, posSendType, pos, rotSendType, rot3x3);
-
+            /// @todo Idea: could have inOrder true and use frame number as the contentID?
             connection->Send(cObserverPositionMessage, false, false, ds);
         }
-    }
-}
-
-void SyncManager::ComputeSyncPriorities(EntitySyncState &entityState, const float3 &observerPos, const float3 &observerRot) const
-{
-    EntitySyncStateMap m;
-    m[entityState.id] = entityState;
-    ComputeSyncPriorities(m, observerPos, observerRot);
-}
-
-//void SyncManager::ComputeSyncPriorities(SceneSyncState *sceneState) const
-void SyncManager::ComputeSyncPriorities(EntitySyncStateMap &entities, const float3 &observerPos, const float3 &observerRot) const
-{
-    if (!observerPos.IsFinite() || !observerRot.IsFinite())
-        return; // camera information not received yet.
-    ScenePtr scene = scene_.lock();
-
-    PROFILE(SyncManager_ComputeSyncPriorities);
-    for(EntitySyncStateMap::iterator it = entities.begin(); it != entities.end(); ++it)
-    {
-        EntitySyncState &entityState = it->second;
-        Entity *entity = scene->EntityById(entityState.id).get(); /**< @todo store weak_ptr to Entity in EntitySyncState */
-        if (!entity)
-            continue; // we (might) end up here e.g. when entity was just deleted
-
-        /// @todo Check do we end up computing sync prio for local entities
-
-        shared_ptr<EC_Placeable> placeable = entity->Component<EC_Placeable>();
-        shared_ptr<EC_Mesh> mesh = entity->Component<EC_Mesh>();
-        shared_ptr<EC_RigidBody> rigidBody = entity->Component<EC_RigidBody>();
-
-        /// @todo sound sources
-        /*
-        shared_ptr<EC_Sound> sound = entity->Component<EC_Sound>();
-        if (sound)
-        {
-            if (sound->spatial.Get() && placeable)
-            {
-                float r = audio->soundOuterRadius.Get();
-                r *= r;
-                entityState.priority = 4.f * pi * r / observerPos.DistanceSq(placeable->WorldPosition());
-            }
-            else
-                entityState.priority = inf;
-        }
-        */
-        /// @todo Handle terrains
-        //shared_ptr<EC_Terrain> terrain = entity->Component<EC_Terrain>();
-        //if (terrain) { ... }
-
-        if (!placeable)
-        {
-            /// @todo Should handle special case entities with rigid body but no placeable?
-            //if (rigidBody)
-            // Non-spatial (probably), use max priority
-            /// @todo Can have f.ex. Terrain component that has its own transform, but it can use Placeable too.
-            entityState.priority = inf;
-        }
-        else if (placeable && !mesh)
-        {
-            // Spatial, but no mesh, for now use a harcoded priority of 20 (updateInterval = 1 / (priority * relevance),
-            // so will probably yield the default SyncManager's update period 1/20th of a second
-            entityState.priority = 20.f;
-            /// @todo retrieve/calculate bounding volumes of possible billboards, particle systems, lights, etc.
-            /// Not going to be easy with Ogre though, especially when running in headless mode.
-        }
-        else if (placeable && mesh)
-        {
-            OBB worldObb;
-            if (framework_->IsHeadless())
-            {
-                // On headless mode, force mesh asset load in order to be able to inspect its AABB.
-                if (!mesh->MeshAsset() && !mesh->meshRef.Get().ref.trimmed().isEmpty())
-                {
-                    mesh->ForceMeshLoad();
-                    continue; // compute the priority next time when mesh asset is available
-                }
-                // EC_Mesh::WorldOBB not usable in headless mode (no Ogre::Entity available),
-                // so we must dig the bounding volume information from OgreMeshAsset (Ogre::Mesh) instead.
-                /// @todo For some meshes (f.ex. floor of the Avatar scene) there seems to be significant discrepancy
-                // between the OBB values when running as headless or not. Investigate.
-                Ogre::MeshPtr ogreMesh = mesh->MeshAsset() ? mesh->MeshAsset()->ogreMesh : Ogre::MeshPtr();
-                if (ogreMesh.isNull())
-                    LogWarning("SyncManager::ComputeSyncPriorities: " + entity->ToString().toStdString() + " has null Ogre mesh " + mesh->GetMeshName());
-                worldObb = !ogreMesh.isNull() ? AABB(ogreMesh->getBounds()) : OBB();
-                worldObb.Transform(placeable->LocalToWorld());
-            }
-            else
-                worldObb = mesh->WorldOBB();
-            float sizeSq = worldObb.SurfaceArea();
-            sizeSq *= sizeSq;
-            float distanceSq = observerPos.DistanceSq(placeable->WorldPosition());
-            entityState.priority = sizeSq/distanceSq;
-            //LogDebug(QString("%1 sizeSq %2 distanceSq %3").arg(entity->ToString()).arg(sizeSq).arg(distanceSq));
-        }
-
-        /// @todo Take direction and velocity of rigid bodies into account
-            //if (rigibBody)
-        /// @todo Hardcoded relevancy of 10 for entities with RigidBody component and 1 for others for now.
-        /// @todo Movement of non-physical entities is too jerky.
-        entityState.relevancy = rigidBody /*entity->Component("EC_Avatar")*/ ? 10.f : 1.f;
-        //LogDebug(QString("%1 P %2 R %3 P*R %4 syncRate %5").arg(entity->ToString()).arg(
-            //entityState.priority).arg(entityState.relevancy).arg(entityState.FinalPriority()).arg(entityState.ComputePrioritizedUpdateInterval(updatePeriod_)));
     }
 }
 
@@ -3029,6 +2934,7 @@ void SyncManager::HandleObserverPosition(UserConnection* source, const char* dat
         syncState->observerPos = pos;
     if (rotSendType)
         syncState->observerRot = RadToDeg(rot.ToEulerZYX());
+    /// @todo if (posSendType || rotSendType) -> notify current prioritizer that new observer position is available
 }
 
 }

--- a/src/Core/TundraProtocolModule/SyncManager.h
+++ b/src/Core/TundraProtocolModule/SyncManager.h
@@ -175,11 +175,9 @@ private:
     void HandleObserverPosition(UserConnection* source, const char* data, size_t numBytes);
     /// Sends client's observer information. @remark Interest management
     void SendObserverPosition(UserConnection* connection, SceneSyncState *senderState);
-    /// (Re)computes priority for entity. @remark Interest management
-    /** @param entity Entity pointer, if available, otherwise retrieved from Scene by ID. */
-    void ComputePriorityForEntitySyncState(SceneSyncState *sceneState, EntitySyncState &entityState, Entity *entity) const;
     /// (Re)computes priorities for all entities in the scene. @remark Interest management
-    void ComputePrioritiesForEntitySyncStates(SceneSyncState *sceneState) const;
+    void ComputeSyncPriorities(EntitySyncStateMap &entities, const float3 &observerPos, const float3 &observerRot) const;
+    void ComputeSyncPriorities(EntitySyncState &entityState, const float3 &observerPos, const float3 &observerRot) const; /**< @overload */
 
     /// Owning module
     TundraLogicModule* owner_;

--- a/src/Core/TundraProtocolModule/SyncState.h
+++ b/src/Core/TundraProtocolModule/SyncState.h
@@ -410,7 +410,7 @@ private:
 
     /// @remark Enables a 'pending' logic in SyncManager, with which a script can throttle the sending of entities to clients.
     StateChangeRequest changeRequest_;
-    bool isServer_;
+    const bool isServer_; // cannot change during SceneSyncState's lifetime
     bool placeholderComponentsSent_;
     u32 userConnectionID_;
 

--- a/src/Core/TundraProtocolModule/SyncState.h
+++ b/src/Core/TundraProtocolModule/SyncState.h
@@ -303,6 +303,13 @@ public:
     virtual ~SceneSyncState();
 
     /// Dirty entities pending processing
+    /// @todo Some other data structure could be used for the dirty object list instead of the current doubly-linked list,
+    /// for example a min-max heap or other type of priority queue. The min-max heap, for example, would remove the need to
+    /// sort the list manually, but would make insertions and removals slower, so, profiling advantages and disadvantages of
+    /// different data structures would be required when seeking the most suitable data structure for the task. 
+    /// Also, maintaining some kind of priority groups or ranges for objects, instead of every object having its own priority,
+    /// could make sense as the priorities can be virtually the same for objects within the same area and small changes in the
+    /// priority don’t have significant effects on the synchronization rate.
     std::list<EntitySyncState*> dirtyQueue; 
 
     /// Entity sync states

--- a/src/Core/TundraProtocolModule/TundraMessages.h
+++ b/src/Core/TundraProtocolModule/TundraMessages.h
@@ -10,7 +10,11 @@ const unsigned long cClientLeftMessage = 103;
 
 // Interest management
 /// @todo const unsigned long cSetObserverMessage = 104; // Server->client, tells what entity to use as the observer
-const unsigned long cObserverPositionMessage = 105; // Client->server only currently, but could be used server->client also to tell that "you are now here".
+/// The message would contain a scene ID and an entity reference (ID or name) of the desired observer entity.
+/// This message would allow the server to tell what entity the client must use as the observer when the client joins the server.
+/// The message could also be client->server and use to negotiate various observer settings (cutoff radius etc.)
+/// @todo ObserverPosition message could be made server->client also to tell the initial position, or to force the position, of the observer.
+const unsigned long cObserverPositionMessage = 105; // Client->server currently
 
 // Scenesync
 // NOTE 106-108 should be reserved for Scene messages (Create, EditProperties, Remove)

--- a/src/Core/TundraProtocolModule/TundraProtocolModuleFwd.h
+++ b/src/Core/TundraProtocolModule/TundraProtocolModuleFwd.h
@@ -36,6 +36,7 @@ struct EntitySyncState;
 struct ComponentSyncState;
 typedef std::map<entity_id_t, EntitySyncState> EntitySyncStateMap;
 struct UserConnectedResponseData;
+class EntityPrioritizer;
 
 typedef QVariantMap LoginPropertyMap; ///< propertyName-propertyValue map of login properties.
 

--- a/src/Core/TundraProtocolModule/TundraProtocolModuleFwd.h
+++ b/src/Core/TundraProtocolModule/TundraProtocolModuleFwd.h
@@ -34,6 +34,7 @@ typedef std::list<UserConnectionPtr> UserConnectionList;
 class SceneSyncState;
 struct EntitySyncState;
 struct ComponentSyncState;
+typedef std::map<entity_id_t, EntitySyncState> EntitySyncStateMap;
 struct UserConnectedResponseData;
 
 typedef QVariantMap LoginPropertyMap; ///< propertyName-propertyValue map of login properties.


### PR DESCRIPTION
<b> Diff for commits I accidentally pushed to rex tundra2 already: https://github.com/realXtend/tundra/compare/1fc66ab44fc763c12144d659787b3380cc38e74b...d6add046ca6e20ec8d886bf4017e14e935e5af44 I saw no value in reverting those commits solely for formality reasons so I left them be. </b>

Priority-based IM implemenation I did for my master’s thesis: http://jultika.oulu.fi/Record/nbnfioulu-201411192004
• Original code: https://github.com/LudoCraft/Tundra/tree/InterestManagement
• Recent work: https://github.com/Adminotech/tundra/tree/InterestManagement

_New Enhancements_
• Some general code cleanup and minor optimizations.
• Client code can register different (C++) interest managers (entity prioritizers) to the system without altering the core Tundra codebase. This allows different types of interest management implementations, depending on the requirements and needs of different types of scenes and applications. It’s also possible to switch between different implementations at runtime.
• The size of the ObserverPosition message was reduced from fixed 25 bytes to 10-12 bytes on average 

_Possible Future Work, To-Dos & Ideas_
• The next step for the filtering technique would be to define a cut off priority which would be used to remove the most unimportant objects from the client’s view in order to ease the client's rendering workload on large scenes.
• ObserverPosition message could be made server-client to tell the initial position, or to force the position, of the observer.
• Ideally, the server should be able to define an output per user threshold, which the server could automatically adjust accordingly to the number of concurrent users.
• Some other data structure could be used for the dirty object list instead of the current doubly-linked list, for example a min-max heap or other type of priority queue. The min-max heap, for example, would remove the need to sort the list manually, but would make insertions and removals slower, so, profiling advantages and disadvantages of different data structures would be required when seeking the most suitable data structure for the task. 
• Also, maintaining some kind of priority groups or ranges for objects, instead of every object having its own priority, could make sense as the priorities can be virtually the same for objects within the same area and small changes in the priority don’t have significant effects on the synchronization rate.
• Also, factoring in an object’s velocity vector (direction and speed) for the relevancy computation would help refine the priority calculation.
• Currently the object priorities are calculated at fixed interval. Server CPU overhead could be observed when the server was computing priorities for many hundreds of objects, especially when number of concurrent users in the world started to grow. Threading the priority computation task could be used as a solution. An alternative approach would be not computing all priorities in a one go, but instead in batches, of say, 100 entities per frame.
• A new SetObserver message, containing a scene ID and an entity reference (ID or name) of the desired observer entity could be added to the protocol. This message would allow the server to tell what entity the client must use as the observer when the client joins the server. 
• A view frustum query –based, or similar, technique for defining client’s interest would be needed for more refined prioritization, meaning incorporating elements of aura-based filtering to the solution.

More documentation and maybe some minor commits to follow in the near future.
